### PR TITLE
Configure WiFi module (ESP-01s)

### DIFF
--- a/rfid-plus-display/rfid-plus-display.ino
+++ b/rfid-plus-display/rfid-plus-display.ino
@@ -58,5 +58,3 @@ void loop() {
     }
   #endif
 }
-
-

--- a/rfid-plus-display/rfid-plus-display.ino
+++ b/rfid-plus-display/rfid-plus-display.ino
@@ -12,6 +12,7 @@
 #define LCD_D6 7
 #define LCD_D7 6
 
+const int SERIAL_BAUD_RATE = 115200;
 
 // Initialize the LCD library and set it to operate using 7 GPIO pins under
 // the 4-bit mode.
@@ -21,10 +22,10 @@ LiquidCrystal lcd(
 );
 
 void setup() {
-  Serial.begin(115200);
-  Serial1.begin(115200);
+  Serial.begin(SERIAL_BAUD_RATE);
+  Serial1.begin(SERIAL_BAUD_RATE);
 
-   // set up the LCD's number of columns and rows:
+  // set up the LCD's number of columns and rows:
   lcd.begin(16, 2);
   // Print a message to the LCD.
   lcd.print("Hello, Warszawa!");

--- a/rfid-plus-display/rfid-plus-display.ino
+++ b/rfid-plus-display/rfid-plus-display.ino
@@ -3,7 +3,6 @@
 #include "Arduino.h"
 #include <LiquidCrystal.h>
 
-
 // LCD Pins Configuration
 #define LCD_RST 12
 #define LCD_EN 11
@@ -39,20 +38,24 @@ void loop() {
   lcd.print(millis() / 1000);
 
 
-  // A serial passthrough is necessary because leonardo board doesn't have
-  // a chip dedicated to managing the serial communication via UART protocol.
-  // Copy from virtual serial line to uart and vice versa
-  if (Serial.available()) {
-    while(Serial.available()){
-      Serial1.write(Serial.read());
+  // SerialPassthrough code is only run when needed.
+  // https://docs.arduino.cc/built-in-examples/communication/SerialPassthrough/
+  #ifdef ARDUINO_AVR_LEONARDO
+    // A serial passthrough is necessary because leonardo board doesn't have
+    // a chip dedicated to managing the serial communication via UART protocol.
+    // Copy from virtual serial line to uart and vice versa
+    if (Serial.available()) {
+      while(Serial.available()){
+        Serial1.write(Serial.read());
+      }
     }
-  }
 
-  if (Serial1.available()) {
-    while(Serial1.available()) {
-      Serial.write(Serial1.read());
+    if (Serial1.available()) {
+      while(Serial1.available()) {
+        Serial.write(Serial1.read());
+      }
     }
-  }
+  #endif
 }
 
 

--- a/rfid-plus-display/rfid-plus-display.ino
+++ b/rfid-plus-display/rfid-plus-display.ino
@@ -12,7 +12,7 @@
 #define LCD_D6 7
 #define LCD_D7 6
 
-const int SERIAL_BAUD_RATE = 115200;
+#define SERIAL_BAUD_RATE 115200
 
 // Initialize the LCD library and set it to operate using 7 GPIO pins under
 // the 4-bit mode.

--- a/wifi-module/builtinfiles.h
+++ b/wifi-module/builtinfiles.h
@@ -5,25 +5,28 @@
  * This file contains long, multiline text variables for  all builtin resources.
  */
 
+#ifndef BUILTIN_FILES_
+#define BUILTIN_FILES_
+
 // rootContent defines content for the route http://rfid.auth.local/
 static const char rootContent[] PROGMEM = R"==(
     <!DOCTYPE html>
-    <html lang='en-GB'>
+    <html lang="en-GB">
     <head><title>WiFi Configuration</title></head>
     <body>
-        <p style='font-weight: bold;'>RFID-based Auth Configuration.</p>
+        <p style="font-weight: bold;">RFID-based Auth Configuration.</p>
         <span>Use this form to configure esp8266 WiFi settings for use in the Station(STA) Mode.</span><br>
         <i>Leading and trailing whitespace characters are trimmed!</i>
-        <form method='POST' action='update'>
-            <p>SSID :<input type='text' placeholder='Network Name' name='ssid' value='%s' maxlength='%d' required/>
+        <form method="POST" action="update">
+            <p>SSID :<input type="text" placeholder="Network Name" name="ssid" value="%s" maxlength="%d" required/>
                 <i>Max characters allowed (%d).</i>
             </p>
-            <p>PWD :<input type='text' placeholder='Password' name='pwd' value='%s' maxlength='%d' required/>
+            <p>PWD :<input type="text" placeholder="Password" name="pwd" value="%s" maxlength="%d" required/>
                 <i>Max characters allowed (%d).</i> Password for WEP/WPA/WPA2.
             </p>
-            <input type='submit' value='Configure'/>
+            <input type="submit" value="Configure"/>
         </form>
-        <p><a href='/quit'>Quit and Restart WiFi module!</a></p>
+        <p><a href="/quit">Quit and Restart WiFi module!</a></p>
     </body>
     </html>
     )==";
@@ -31,15 +34,15 @@ static const char rootContent[] PROGMEM = R"==(
 // notFoundContent defines the 404 error content.
 static const char notFoundContent[] PROGMEM = R"==(
     <!DOCTYPE html>
-    <html lang='en-GB'>
+    <html lang="en-GB">
     <head>
     <title>Not found</title>
     </head>
     <body>
     <h1>404 - Not Found!</h1>
-    <p><a href='/'>Start Configuration Again!</a></p>
+    <p><a href="/">Start Configuration Again!</a></p>
     or
-    <p><a href='/quit'>Quit and Restart WiFi module!</a></p>
+    <p><a href="/quit">Quit and Restart WiFi module!</a></p>
     </body>
     </html>
     )==";
@@ -47,25 +50,25 @@ static const char notFoundContent[] PROGMEM = R"==(
 // updateSuccessfulContent defines content for the route http://rfid.auth.local/update
 static const char updateSuccessfulContent[] PROGMEM = R"==(
     <!DOCTYPE html>
-    <html lang='en-GB'>
+    <html lang="en-GB">
     <head>
     <title>Update Successful</title>
     </head>
     <body>
-    <h4>The WiFi Configuration Update Was <span style='color:red;'>%s</span> Successful!!! :)</h4>
+    <h4>The WiFi Configuration Update Was <span style="color:red;">%s</span> Successful!!! :)</h4>
     <i>Current WiFi Settings for Use in the Station (STA) Mode</i>
-    <p><i>WiFi Access Point Name (SSID):</i> '<strong>%s</strong>'</p>
-    <p><i>WiFi Password (WEP/WPA/WPA2):</i> '<strong>%s</strong>'</p>
-    <p><a href='/'>Reset the WiFi configuration!</a></p>
+    <p><i>WiFi Access Point Name (SSID):</i> "<strong>%s</strong>"</p>
+    <p><i>WiFi Password (WEP/WPA/WPA2):</i> "<strong>%s</strong>"</p>
+    <p><a href="/">Reset the WiFi configuration!</a></p>
     or
-    <p><a href='/quit'>Quit and Restart WiFi module!</a></p>
+    <p><a href="/quit">Quit and Restart WiFi module!</a></p>
     </body>
     )==";
 
 // exitConfigModeContent defines content for the route http://rfid.auth.local/quit
 static const char exitConfigModeContent[] PROGMEM = R"==(
     <!DOCTYPE html>
-    <html lang='en-GB'>
+    <html lang="en-GB">
     <head>
     <title>Bye Bye</title>
     </head>
@@ -75,3 +78,5 @@ static const char exitConfigModeContent[] PROGMEM = R"==(
     </body>
     </html>
     )==";
+  
+#endif

--- a/wifi-module/builtinfiles.h
+++ b/wifi-module/builtinfiles.h
@@ -28,6 +28,7 @@ static const char rootContent[] PROGMEM = R"==(
             <p>PWD :<input type="text" placeholder="Password" name="pwd" value="%s" maxlength="%d" required/>
                 <i>Max characters allowed (%d).</i> Password for WEP/WPA/WPA2.
             </p>
+            <input type="reset" value="Reset"/>
             <input type="submit" value="Configure"/>
         </form>
         <p><a href="/quit">Quit and Restart WiFi module!</a></p>

--- a/wifi-module/builtinfiles.h
+++ b/wifi-module/builtinfiles.h
@@ -8,11 +8,15 @@
 #ifndef BUILTIN_FILES_
 #define BUILTIN_FILES_
 
-// rootContent defines content for the route http://rfid.auth.local/
+// rootContent defines content for the route http://rfid_auth.local/
 static const char rootContent[] PROGMEM = R"==(
     <!DOCTYPE html>
     <html lang="en-GB">
-    <head><title>WiFi Configuration</title></head>
+    <head>
+    <title>WiFi Configuration</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
     <body>
         <p style="font-weight: bold;">RFID-based Auth Configuration.</p>
         <span>Use this form to configure esp8266 WiFi settings for use in the Station(STA) Mode.</span><br>
@@ -36,6 +40,8 @@ static const char notFoundContent[] PROGMEM = R"==(
     <!DOCTYPE html>
     <html lang="en-GB">
     <head>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Not found</title>
     </head>
     <body>
@@ -47,12 +53,14 @@ static const char notFoundContent[] PROGMEM = R"==(
     </html>
     )==";
 
-// updateSuccessfulContent defines content for the route http://rfid.auth.local/update
+// updateSuccessfulContent defines content for the route http://rfid_auth.local/update
 static const char updateSuccessfulContent[] PROGMEM = R"==(
     <!DOCTYPE html>
     <html lang="en-GB">
     <head>
     <title>Update Successful</title>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     </head>
     <body>
     <h4>The WiFi Configuration Update Was <span style="color:red;">%s</span> Successful!!! :)</h4>
@@ -61,16 +69,17 @@ static const char updateSuccessfulContent[] PROGMEM = R"==(
     <p><i>WiFi Password (WEP/WPA/WPA2):</i> "<strong>%s</strong>"</p>
     <p><a href="/">Reset the WiFi configuration!</a></p>
     or
-    <p><a href="/quit">Quit and Restart WiFi module!</a></p>
+    <p><a href="/quit">Save and Restart WiFi module!</a></p>
     </body>
     )==";
 
-// exitConfigModeContent defines content for the route http://rfid.auth.local/quit
+// exitConfigModeContent defines content for the route http://rfid_auth.local/quit
 static const char exitConfigModeContent[] PROGMEM = R"==(
     <!DOCTYPE html>
     <html lang="en-GB">
     <head>
     <title>Bye Bye</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     </head>
     <body>
     <h1>Bye! :)</h1>

--- a/wifi-module/builtinfiles.h
+++ b/wifi-module/builtinfiles.h
@@ -19,8 +19,8 @@ static const char rootContent[] PROGMEM = R"==(
     </head>
     <body>
         <p style="font-weight: bold;">RFID-based Auth Configuration.</p>
-        <span>Use this form to configure esp8266 WiFi settings for use in the Station(STA) Mode.</span><br>
-        <i>Leading and trailing whitespace characters are trimmed!</i>
+        <span>Use this form to configure esp8266 WiFi settings for use in the Station (STA) Mode.</span><br>
+        <i>Leading and trailing whitespace characters will be trimmed!</i>
         <form method="POST" action="update">
             <p>SSID :<input type="text" placeholder="Network Name" name="ssid" value="%s" maxlength="%d" required/>
                 <i>Max characters allowed (%d).</i>
@@ -64,7 +64,7 @@ static const char updateSuccessfulContent[] PROGMEM = R"==(
     </head>
     <body>
     <h4>The WiFi Configuration Update Was <span style="color:red;">%s</span> Successful!!! :)</h4>
-    <i>Current WiFi Settings for Use in the Station (STA) Mode</i>
+    <i>Current WiFi Settings for use in the Station (STA) mode:</i>
     <p><i>WiFi Access Point Name (SSID):</i> "<strong>%s</strong>"</p>
     <p><i>WiFi Password (WEP/WPA/WPA2):</i> "<strong>%s</strong>"</p>
     <p><a href="/">Reset the WiFi configuration!</a></p>
@@ -83,7 +83,7 @@ static const char exitConfigModeContent[] PROGMEM = R"==(
     </head>
     <body>
     <h1>Bye! :)</h1>
-    <em>WiFi Module is restarting, therefore exiting this settings configuration mode!</em>
+    <em>WiFi module is restarting and exiting this settings configuration mode!</em>
     </body>
     </html>
     )==";

--- a/wifi-module/builtinfiles.h
+++ b/wifi-module/builtinfiles.h
@@ -1,6 +1,6 @@
 /**
  * @file builtinfiles.h
- * @brief This file is part of the WebServer example for the wifi-module.
+ * @brief This file is part of the web server config for the wifi-module.
  *  
  * This file contains long, multiline text variables for  all builtin resources.
  */

--- a/wifi-module/builtinfiles.h
+++ b/wifi-module/builtinfiles.h
@@ -1,0 +1,77 @@
+/**
+ * @file builtinfiles.h
+ * @brief This file is part of the WebServer example for the wifi-module.
+ *  
+ * This file contains long, multiline text variables for  all builtin resources.
+ */
+
+// rootContent defines content for the route http://rfid.auth.local/
+static const char rootContent[] PROGMEM = R"==(
+    <!DOCTYPE html>
+    <html lang='en-GB'>
+    <head><title>WiFi Configuration</title></head>
+    <body>
+        <p style='font-weight: bold;'>RFID-based Auth Configuration.</p>
+        <span>Use this form to configure esp8266 WiFi settings for use in the Station(STA) Mode.</span><br>
+        <i>Leading and trailing whitespace characters are trimmed!</i>
+        <form method='POST' action='update'>
+            <p>SSID :<input type='text' placeholder='Network Name' name='ssid' value='%s' maxlength='%d' required/>
+                <i>Max characters allowed (%d).</i>
+            </p>
+            <p>PWD :<input type='text' placeholder='Password' name='pwd' value='%s' maxlength='%d' required/>
+                <i>Max characters allowed (%d).</i> Password for WEP/WPA/WPA2.
+            </p>
+            <input type='submit' value='Configure'/>
+        </form>
+        <p><a href='/quit'>Quit and Restart WiFi module!</a></p>
+    </body>
+    </html>
+    )==";
+
+// notFoundContent defines the 404 error content.
+static const char notFoundContent[] PROGMEM = R"==(
+    <!DOCTYPE html>
+    <html lang='en-GB'>
+    <head>
+    <title>Not found</title>
+    </head>
+    <body>
+    <h1>404 - Not Found!</h1>
+    <p><a href='/'>Start Configuration Again!</a></p>
+    or
+    <p><a href='/quit'>Quit and Restart WiFi module!</a></p>
+    </body>
+    </html>
+    )==";
+
+// updateSuccessfulContent defines content for the route http://rfid.auth.local/update
+static const char updateSuccessfulContent[] PROGMEM = R"==(
+    <!DOCTYPE html>
+    <html lang='en-GB'>
+    <head>
+    <title>Update Successful</title>
+    </head>
+    <body>
+    <h4>The WiFi Configuration Update Was <span style='color:red;'>%s</span> Successful!!! :)</h4>
+    <i>Current WiFi Settings for Use in the Station (STA) Mode</i>
+    <p><i>WiFi Access Point Name (SSID):</i> '<strong>%s</strong>'</p>
+    <p><i>WiFi Password (WEP/WPA/WPA2):</i> '<strong>%s</strong>'</p>
+    <p><a href='/'>Reset the WiFi configuration!</a></p>
+    or
+    <p><a href='/quit'>Quit and Restart WiFi module!</a></p>
+    </body>
+    )==";
+
+// exitConfigModeContent defines content for the route http://rfid.auth.local/quit
+static const char exitConfigModeContent[] PROGMEM = R"==(
+    <!DOCTYPE html>
+    <html lang='en-GB'>
+    <head>
+    <title>Bye Bye</title>
+    </head>
+    <body>
+    <h1>Bye! :)</h1>
+    <em>WiFi Module is restarting, therefore exiting this settings configuration mode!</em>
+    </body>
+    </html>
+    )==";

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -136,11 +136,11 @@ void setup() {
 // the loop function runs over and over again forever
 void loop() {
   // Switch off builtin status light.
-  digitalWrite(LED_BUILTIN, LOW);
+  digitalWrite(LED_BUILTIN, HIGH);
   // The WiFi connection is active and serial data has been received 
   if (WiFi.status() == WL_CONNECTED && Serial.available()) {
     // Switch on builtin status light to indicate API connection activity.
-    digitalWrite(LED_BUILTIN, HIGH);
+    digitalWrite(LED_BUILTIN, LOW);
 
     WiFiClient client;
     HTTPClient http;

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -40,9 +40,9 @@ const char* SERVER_API_URL = "http://dmigwi.atwebpages.com/auth/time.php";
 const byte MAX_SSID_LEN = 32; // A max of 32 characters allowed.
 const byte MAX_PASS_LEN = 64; // A max of 64 characters allowed.
 
-// Delay Timeout is set to 1 minute after which, the network connection
+// Delay Timeout is set to 1min and 30sec after which, the network connection.
 // attempts are aborted.
-const int CONNECTION_TIMEOUT = 60000;
+const int CONNECTION_TIMEOUT = 90000;
 
 // STORAGE_ADDRESS defines the location where wifi setting will be stored in the
 // EEPROM storage.
@@ -70,6 +70,7 @@ void setup() {
 
   // Delay allows the serial interface to be ready.
   for (int i=0;i<5;i++) {
+    // Toggle ON and OFF LED state.
     digitalWrite(LED_BUILTIN, (digitalRead(LED_BUILTIN)==HIGH) ? LOW : HIGH);
     Serial.print(".");
     delay(1000);
@@ -128,6 +129,7 @@ void setup() {
 
   // blink 5 times to indicate that WiFi connectivity is working as expected.
   for (int i=0;i<5;i++) {
+    // Toggle ON and OFF LED state.
     digitalWrite(LED_BUILTIN, (digitalRead(LED_BUILTIN)==HIGH) ? LOW : HIGH);
     delay(1000);
   }
@@ -198,14 +200,10 @@ void loop() {
 bool isWiFiConnection() {
   // Wait for connection success status only till connection timeout.
   while (WiFi.status() != WL_CONNECTED && millis() <= CONNECTION_TIMEOUT) {
+    // Toggle ON and OFF LED state.
     digitalWrite(LED_BUILTIN, (digitalRead(LED_BUILTIN)==HIGH) ? LOW : HIGH);
-    delay(2000);
-    #ifdef DEBUG
-    Serial.print(F("\t. Error: "));
-    Serial.println(getWiFiStatusMsg());
-    #else
     Serial.print(".");
-    #endif
+    delay(1000);
   }
 
   digitalWrite(LED_BUILTIN, HIGH);
@@ -239,7 +237,8 @@ void setUpConfigAP() {
   Serial.println(isSet ? "Ready" : "Failed!");
   
   Serial.print(F("AP SSID :'"));
-  Serial.println(AP_SSID);
+  Serial.print(AP_SSID);
+  Serial.println(F("'"));
   Serial.print(F("AP Password :'"));
   Serial.print(AP_Password);
   Serial.println(F("'"));

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -40,9 +40,9 @@ const String SERVER_API_URL = "http://dmigwi.atwebpages.com/auth/time.php";
 const byte MAX_SSID_LEN = 32; // A max of 32 characters allowed.
 const byte MAX_PASS_LEN = 64; // A max of 64 characters allowed.
 
-// Delay Timeout is set to 30 sec after which, the network connection
+// Delay Timeout is set to 1 minute after which, the network connection
 // attempts are aborted.
-const int CONNECTION_TIMEOUT = 30000;
+const int CONNECTION_TIMEOUT = 60000;
 
 // STORAGE_ADDRESS defines the location where wifi setting will be stored in the
 // EEPROM storage.
@@ -190,8 +190,13 @@ bool isWiFiConnection() {
   // Wait for connection success status only till connection timeout.
   while (WiFi.status() != WL_CONNECTED && millis() <= CONNECTION_TIMEOUT) {
     digitalWrite(LED_BUILTIN, (digitalRead(LED_BUILTIN)==HIGH) ? LOW : HIGH);
-    delay(1000);
+    delay(2000);
+    #ifdef DEBUG
+    Serial.print(F("\t. Error: "));
+    Serial.println(getWiFiStatusMsg());
+    #else
     Serial.print(".");
+    #endif
   }
 
   digitalWrite(LED_BUILTIN, HIGH);

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -2,11 +2,17 @@
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>
+#include <ESP8266HTTPClient.h>
 
 // The text of builtin files are in this header file
 #include "builtinfiles.h"
 
-// BUILTIN_LED defines the builtin led on GPIO2 in the ESP-01s schematics.
+// SERIAL_BAUD_RATE defines the speed of communication on the serial interface.
+#define SERIAL_BAUD_RATE 115200
+// EEPROM_SIZE defines the EEPROM memory size to initialize.
+#define EEPROM_SIZE 320
+
+// LED_BUILTIN defines the builtin led on GPIO2 in the ESP-01s schematics.
 // This LED should provide the visual confirmation of whether the chip is
 // running on the normal mode or WiFi settings configuration mode.
 // During normal mode, the LED should blink atleast every 1secs,
@@ -14,10 +20,10 @@
 // is active.
 // The second confirmation of the WiFi settings mode being active should be the
 // AP_SSID appearing on the available networks on scanning the visible wireless networks.
-#define BUILTIN_LED 2
+//#define LED_BUILTIN 2
 
 // uncomment next line to get debug messages output to Serial link
-// #define DEBUG
+#define DEBUG
 
 // When setting up the AP mode is used to set the Station WiFi settings the
 // following configuration is used:
@@ -25,48 +31,59 @@ const String AP_SSID = "RFID-based-Auth";
 const String AP_Password = "Adm1n$tr8oR";
 
 // multicast DNS is used to attach '.local' suffix to create the complete domain name
-// (http://rfid.auth.local). This url is mapped to the server running in the AP network.
-const String AP_Server_Domain = "rfid.auth";
+// (http://rfid_auth.local). This url is mapped to the server running in the AP network.
+const String AP_Server_Domain = "rfid_auth";
 
-const int SERIAL_BAUD_RATE = 115200;
-const int MAX_SSID_LEN = 32; // Max of 32 characters allowed.
-const int MAX_PASSWORD_LEN = 64; // Max of 64 characters allowed.
+// SERVER_API_URL defines the URL to which the HTTP client will make API calls to.
+const String SERVER_API_URL = "http://dmigwi.atwebpages.com/auth/time.php";
 
-// Delay Timeout is set to 1 minute after which, the network connection
+const byte MAX_SSID_LEN = 32; // A max of 32 characters allowed.
+const byte MAX_PASS_LEN = 64; // A max of 64 characters allowed.
+
+// Delay Timeout is set to 30 sec after which, the network connection
 // attempts are aborted.
-const int CONNECTION_TIMEOUT = 60000;
+const int CONNECTION_TIMEOUT = 30000;
 
 // STORAGE_ADDRESS defines the location where wifi setting will be stored in the
 // EEPROM storage.
-const float STORAGE_ADDRESS = 0;
+const int STORAGE_ADDRESS = 0;
 
 // Struct Object to hold the station mode wifi settings.
 struct WifiConfigSettings{
   char SSID[MAX_SSID_LEN];
-  char Password[MAX_PASSWORD_LEN];
+  char Password[MAX_PASS_LEN];
 };
 
-WifiConfigSettings settings = WifiConfigSettings();
+WifiConfigSettings settings;
 
 // Server indicates the created server interface
 ESP8266WebServer server(80);
 
 void setup() {
-  // Set the GPIO2 as output and
-  pinMode(BUILTIN_LED, OUTPUT);
-  digitalWrite(BUILTIN_LED, HIGH);
-
+  // Initialize the serial interface.
   Serial.begin(SERIAL_BAUD_RATE);
+
+  // Set the GPIO2 Pin as output and set it high.
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+  Serial.println(".");
+
   // Delay allows the serial interface to be ready.
   for (int i=0;i<5;i++) {
+    digitalWrite(LED_BUILTIN, (digitalRead(LED_BUILTIN)==HIGH) ? LOW : HIGH);
     Serial.print(".");
     delay(1000);
   }
 
+  digitalWrite(LED_BUILTIN, LOW);
+  Serial.println(".");
+
+  //Init EEPROM
+  EEPROM.begin(EEPROM_SIZE);
   Serial.println(F("Booting the WIFI Module"));
 
   // Read the preset Station WIFI Settings from EEPROM.
-  EEPROM.get(STORAGE_ADDRESS, settings);
+  ReadWiFiSettingsInEEPROM();
   String ssid = String(settings.SSID);
   String password = String(settings.Password);
 
@@ -84,12 +101,15 @@ void setup() {
   // station mode WIFI Settings.
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
-
+  // By default the WiFi modules activated the power saving mode with results random
+  // wifi disconnects. Disabling it allows consistent WiFi connectivity.
+  WiFi.setSleepMode(WIFI_NONE_SLEEP); // Disable the power saving sleep mode.
 
   if (!isWiFiConnection()) {
     // Wifi connection via Station mode failed. Set the WiFi mode to AP and attempt
     // to configure the station mode wifi settings.
     setUpConfigAP();
+    digitalWrite(LED_BUILTIN, LOW);
 
     // The only way to exit this infinite loop is to restart the WiFi module CPU after
     // setting the correct Station mode WiFi settings.
@@ -99,24 +119,66 @@ void setup() {
     }
   }
 
+  // Shutdown the EEPROM interface
+  EEPROM.end();
+
   #ifdef DEBUG
   Serial.println("Station WiFi Mode Active");
   #endif
 
   // blink 5 times to indicate that WiFi connectivity is working as expected.
   for (int i=0;i<5;i++) {
-    digitalWrite(BUILTIN_LED, LOW);
+    digitalWrite(LED_BUILTIN, (digitalRead(LED_BUILTIN)==HIGH) ? LOW : HIGH);
     delay(1000);
-    digitalWrite(BUILTIN_LED, HIGH);
   }
 }
 
 // the loop function runs over and over again forever
 void loop() {
-  // digitalWrite(LED_BUILTIN, LOW);  // Turn the LED on (Note that LOW is the voltage level
-  // delay(1000);                      // Wait for a second
-  // digitalWrite(LED_BUILTIN, HIGH);  // Turn the LED off by making the voltage HIGH
-  // delay(1000);                      // Wait for two seconds (to demonstrate the active low LED)
+  // Switch off builtin status light.
+  digitalWrite(LED_BUILTIN, LOW);
+  // The WiFi connection is active and serial data has been received 
+  if (WiFi.status() == WL_CONNECTED && Serial.available()) {
+    // Switch on builtin status light to indicate API connection activity.
+    digitalWrite(LED_BUILTIN, HIGH);
+
+    WiFiClient client;
+    HTTPClient http;
+
+    #ifdef DEBUG 
+    Serial.println("[HTTP] begin...");
+    #endif
+
+    // configure traged server and url
+    http.begin(client, SERVER_API_URL);  // HTTP
+    http.addHeader("Content-Type", "application/json");
+
+    #ifdef DEBUG 
+    Serial.println("[HTTP] POST...");
+    #endif
+    // start connection and send HTTP header and body
+    int httpCode = http.POST("{\"hello\":\"world\"}");
+
+    // httpCode will be negative on error
+    if (httpCode > 0) {
+      // HTTP header has been send and Server response header has been handled
+      #ifdef DEBUG
+      Serial.printf("[HTTP] POST... code: %d\n", httpCode);
+      #endif
+
+      // file found at server
+      if (httpCode == HTTP_CODE_OK) {
+        const String& payload = http.getString();
+        Serial.println("received payload:\n<<");
+        Serial.println(payload);
+        Serial.println(">>");
+      }
+    } else {
+      Serial.printf("[HTTP] POST... failed, error: %s\n", http.errorToString(httpCode).c_str());
+    }
+
+    http.end();
+  }
 }
 
 /*
@@ -127,18 +189,22 @@ void loop() {
 bool isWiFiConnection() {
   // Wait for connection success status only till connection timeout.
   while (WiFi.status() != WL_CONNECTED && millis() <= CONNECTION_TIMEOUT) {
-    delay(500);
+    digitalWrite(LED_BUILTIN, (digitalRead(LED_BUILTIN)==HIGH) ? LOW : HIGH);
+    delay(1000);
     Serial.print(".");
   }
+
+  digitalWrite(LED_BUILTIN, HIGH);
+  Serial.println(".");
 
   #ifdef DEBUG
   if (WiFi.isConnected()) {
     Serial.println(F("Connecting to AP was Successful"));
-    Serial.print(F("IP Address :'"));
+    Serial.print(F("IP Address: "));
     Serial.println(WiFi.localIP());
   } else {
     Serial.println(F("Connecting to Wifi AP Failed!"));
-    Serial.print(F("Error Msg :'"));
+    Serial.print(F("Error Msg: "));
     Serial.println(getWiFiStatusMsg());
   }
   #endif
@@ -169,7 +235,7 @@ void setUpConfigAP() {
   isSet  = MDNS.begin(AP_Server_Domain);
   if (isSet) { 
     #ifdef DEBUG
-    Serial.println("MDNS responder started");
+    Serial.println(F("MDNS responder is running on: http://rfid_auth.local"));
     #endif
   }
 
@@ -232,12 +298,12 @@ String getWiFiStatusMsg() {
 // Server Pages
 
 /*
-  handleRoot returns the webpage to be viewed when a GET request is made to (http://rfid.auth.local).
+  handleRoot returns the webpage to be viewed when a GET request is made to (http://rfid_auth.local).
 */
 void handleRoot() {
   char buffer[1500];  // Preallocate a large chunk to avoid memory fragmentation
   sprintf(buffer, rootContent, settings.SSID, MAX_SSID_LEN, MAX_SSID_LEN,
-          settings.Password, MAX_PASSWORD_LEN, MAX_PASSWORD_LEN);
+          settings.Password, MAX_PASS_LEN, MAX_PASS_LEN);
   server.send(200, "text/html", buffer);
 }
 
@@ -254,6 +320,12 @@ void handleShutdown() {
   server.stop();
 
   delay(1500); // Wait for the server to completely shutdown.
+
+  #ifdef DEBUG
+  Serial.println(F("Shutting the EEPROM Interface!"));
+  #endif
+  // Shutdown the EEPROM Interface
+  EEPROM.end();
 
   #ifdef DEBUG
   Serial.println(F("Restarting the ESP-01 chip CPU"));
@@ -276,13 +348,24 @@ void handleUpdateSettings() {
     String pwd = server.arg("pwd");
     ssid.trim(); // Remove trailing and preceding whitespace characters.
     pwd.trim(); // Remove trailing and preceding whitespace characters.
+
+    #ifdef DEBUG
+    Serial.print(F("Detected SSID :'"));
+    Serial.print(ssid);
+    Serial.println(F("'"));
+    Serial.print(F("Detected Password :'"));
+    Serial.print(pwd);
+    Serial.println(F("'"));
+    #endif
   
     if (ssid.length() > 0 && pwd.length() > 0) {
-      ssid.toCharArray(settings.SSID, ssid.length()); // set the ssid string to the struct.
-      pwd.toCharArray(settings.Password, pwd.length()); // set the pwd string to the struct.
+      ssid.toCharArray(settings.SSID, ssid.length()+1); // set the ssid string to the struct.
+      pwd.toCharArray(settings.Password, pwd.length()+1); // set the pwd string to the struct.
 
       // Update the EEPROM with the latest settings.
       EEPROM.put(STORAGE_ADDRESS, settings);
+      // Commit the EEPROM Changes.
+      EEPROM.commit();
 
       // Remove the failure emphasis text indicating success of the update operation.
       updateStatus[0] = '\0'; // Clearing the char array.
@@ -293,3 +376,35 @@ void handleUpdateSettings() {
   sprintf(buffer, updateSuccessfulContent, updateStatus, settings.SSID, settings.Password);
   server.send(200, "text/html", buffer);
 }
+
+// ReadWiFiSettingsInEEPROM reads the contents of the STORAGE_ADDRESS an formats the read data.
+// If the address read was empty, the default byte stored in that location is 0xff.
+// It removes the EEPROM empty char from the data read.
+void ReadWiFiSettingsInEEPROM() {
+  EEPROM.get(STORAGE_ADDRESS, settings);
+  String ssid = replaceEmptyBytes(settings.SSID, MAX_SSID_LEN);
+  String pwd = replaceEmptyBytes(settings.Password, MAX_PASS_LEN);
+
+  ssid.toCharArray(settings.SSID, ssid.length()+1); // set the ssid string to the struct.
+  pwd.toCharArray(settings.Password, pwd.length()+1); // set the pwd string to the struct.
+}
+
+// replaceEmptyBytes it replaces all the 0xff EEPROM empty characters with 0x20 which is a whitespace.
+// It then removes the trailing and preceeding whitespaces before reassigning the formatted array
+// back to the original array.
+String replaceEmptyBytes(char* rawStr, byte charCount){
+  char data[charCount];
+  for (byte i= 0; i<charCount; i++) {
+    byte rawChar = rawStr[i]; 
+    if (rawStr[i] == 0xff){ // check for EEPROM empty char value.
+      rawChar = 0x20; // insert a whitespace character has hex value of 0x20
+    } 
+    data[i] = rawChar;
+  }
+
+  String val = String(data);
+  val.trim(); // Remove preceeding and trailing white spaces.
+  return val;
+}
+
+

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -27,15 +27,15 @@
 
 // When setting up the AP mode is used to set the Station WiFi settings the
 // following configuration is used:
-const String AP_SSID = "RFID-based-Auth";
-const String AP_Password = "Adm1n$tr8oR";
+const char* AP_SSID = "RFID-based-Auth";
+const char* AP_Password = "Adm1n$tr8oR";
 
 // multicast DNS is used to attach '.local' suffix to create the complete domain name
 // (http://rfid_auth.local). This url is mapped to the server running in the AP network.
-const String AP_Server_Domain = "rfid_auth";
+const char* AP_Server_Domain = "rfid_auth";
 
 // SERVER_API_URL defines the URL to which the HTTP client will make API calls to.
-const String SERVER_API_URL = "http://dmigwi.atwebpages.com/auth/time.php";
+const char* SERVER_API_URL = "http://dmigwi.atwebpages.com/auth/time.php";
 
 const byte MAX_SSID_LEN = 32; // A max of 32 characters allowed.
 const byte MAX_PASS_LEN = 64; // A max of 64 characters allowed.
@@ -284,10 +284,10 @@ String getWiFiStatusMsg() {
   #ifdef DEBUG
   switch (WiFi.status()) {
     case WL_IDLE_STATUS:
-      status = "Wi-Fi is in process of changing between statuses";
+      status = "Wi-Fi in between statuses";
       break;
     case WL_NO_SSID_AVAIL:
-      status = "Configured SSID cannot be reached";
+      status = "SSID cannot be reached";
       break;
     case WL_SCAN_COMPLETED:
       status = "Scan Completed";
@@ -422,5 +422,3 @@ String replaceEmptyBytes(char* rawStr, byte charCount){
   val.trim(); // Remove preceeding and trailing white spaces.
   return val;
 }
-
-

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -108,15 +108,19 @@ void setup() {
   Serial.print(F("Password :'"));
   Serial.print(password);
   Serial.println(F("'"));
+  Serial.print(F("Hostname :'"));
+  Serial.print(WiFi.hostname());
+  Serial.println(F("'"));
   #endif
 
   // The device by default it runs on Station mode. AP mode only used to update
   // station mode WIFI Settings.
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
-  // By default the WiFi modules activated the power saving mode with results random
-  // wifi disconnects. Disabling it allows consistent WiFi connectivity.
-  WiFi.setSleepMode(WIFI_NONE_SLEEP); // Disable the power saving sleep mode.
+  // Automatic Light Sleep at DTIM listen interval of 3 allows the WiFi module
+  // to easily establish and maintain connections.
+  // https://github.com/esp8266/Arduino/blob/685f2c97ff4b3c76b437a43be86d1dfdf6cb33e3/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp#L281-L305
+  WiFi.setSleepMode(WIFI_LIGHT_SLEEP, 3);
 
   if (!isWiFiConnection()) {
     // Wifi connection via Station mode failed. Set the WiFi mode to AP and attempt

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -1,0 +1,272 @@
+#include <EEPROM.h>
+#include <ESP8266WiFi.h>
+#include <ESP8266WebServer.h>
+#include <ESP8266mDNS.h>
+#include <StreamString.h>
+
+// The text of builtin files are in this header file
+#include "builtinfiles.h"
+
+// BUILTIN_LED defines the builtin led on GPIO2 in the ESP-01s schematics.
+// This LED should provide the visual confirmation of whether the chip is
+// running on the normal mode or WiFi settings configuration mode.
+// During normal mode, the LED should blink atleast every 1secs,
+// if it stays on for longer than that most likely the WiFi configuration mode
+// is active.
+// The second confirmation of the WiFi settings mode being active should be the
+// AP_SSID appearing on the available networks on scanning the visible wireless networks.
+#define BUILTIN_LED 2
+
+// uncomment next line to get debug messages output to Serial link
+#define DEBUG
+// Trace output simplified, can be deactivated here
+#define Trace(...) #ifdef DEBUG; Serial.print(__VA_ARGS__); #endif;
+// Traceln output simplified, can be deactivated here
+#define Traceln(...) #ifdef DEBUG; Serial.println(__VA_ARGS__); #endif;
+
+// When setting up the AP mode is used to set the Station WiFi settings the
+// following configuration is used:
+const string AP_SSID = "RFID-based-Auth";
+const string AP_Password = "Adm1n$tr8oR";
+
+// multicast DNS is used to attach '.local' suffix to create the complete domain name
+// (http://rfid.auth.local). This url is mapped to the server running in the AP network.
+const string AP_Server_Domain = "rfid.auth";
+
+const int SERIAL_BAUD_RATE = 115200;
+const int MAX_SSID_LEN = 32; // Max of 32 characters allowed.
+const int MAX_PASSWORD_LEN = 64; // Max of 64 characters allowed.
+
+// Delay Timeout is set to 1 minute after which, the network connection
+// attempts are aborted.
+const int CONNECTION_TIMEOUT = 60000;
+
+// STORAGE_ADDRESS defines the location where wifi setting will be stored in the
+// EEPROM storage.
+const float STORAGE_ADDRESS = 0;
+
+// Struct Object to hold the station mode wifi settings.
+struct WifiConfigSettings{
+  char SSID[MAX_SSID_LEN];
+  char Password[MAX_PASSWORD_LEN];
+};
+
+WifiConfigSettings settings;
+
+// Server indicates the created server interface
+ESP8266WebServer server(80);
+
+void setup() {
+  // Set the GPIO2 as output and
+  pinMode(BUILTIN_LED, OUTPUT);
+  digitalWrite(BUILTIN_LED, HIGH);
+
+  Serial.begin(SERIAL_BAUD_RATE);
+  // Delay allows the serial interface to be ready.
+  for (int i=0;i<5;i++) {
+    Serial.print(".");
+    delay(1000);
+  }
+
+  Traceln(F("Booting the WIFI Module"));
+
+  // Read the preset Station WIFI Settings from EEPROM.
+  EEPROM.get(STORAGE_ADDRESS, &settings);
+
+  string ssid = string(settings.SSID);
+  string password = string(settings.Password);
+
+  Traceln(F("Attempting a connection to AP"));
+  Trace(F("SSID :'"));
+  Trace(F(ssid));
+  Traceln("'");
+  Trace(F("Password :'"));
+  Trace(F(password));
+  Traceln("'");
+
+  // The device by default it runs on Station mode. AP mode only used to update
+  // station mode WIFI Settings.
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+
+
+  if (!isWiFiConnection()) {
+    // Wifi connection via Station mode failed. Set the WiFi mode to AP and attempt
+    // to configure the station mode wifi settings.
+    setUpConfigAP();
+
+    // The only way to exit this infinite loop is to restart the WiFi module CPU after
+    // setting the correct Station mode WiFi settings.
+    while(1) {
+      server.handleClient();
+      MDNS.update();
+    }
+  }
+
+  Traceln("Station WiFi Mode Active");
+  // blink 5 times to indicate that WiFi connectivity is working as expected.
+  for (int i=0;i<5;i++) {
+    digitalWrite(BUILTIN_LED, LOW);
+    delay(1000)
+    digitalWrite(BUILTIN_LED, HIGH);
+  }
+}
+
+// the loop function runs over and over again forever
+void loop() {
+  // digitalWrite(LED_BUILTIN, LOW);  // Turn the LED on (Note that LOW is the voltage level
+  // delay(1000);                      // Wait for a second
+  // digitalWrite(LED_BUILTIN, HIGH);  // Turn the LED off by making the voltage HIGH
+  // delay(1000);                      // Wait for two seconds (to demonstrate the active low LED)
+}
+
+/*
+  isWiFiConnection waits for the wifi connection status  to change to connected
+  of the timeout to expire, whichever comes first. It then returns a boolean value
+  indicating if the connection was successful or not.
+*/
+bool isWiFiConnection() {
+  // Wait for connection success status only till connection timeout.
+  while (WiFi.status() != WL_CONNECTED && millis() <= CONNECTION_TIMEOUT) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  if (WiFi.isConnected()) {
+    Traceln(F("Connecting to AP was Successful"));
+    Trace(F("IP Address :'"));
+    Traceln(F(WiFi.localIP()));
+  }else {
+    Traceln(F("Connecting to Wifi AP Failed!"));
+    Trace(F("Error Msg :'"));
+    Traceln(F(getWiFiStatusMsg()));
+  }
+  
+  return WiFi.isConnected();
+}
+
+/*
+  setUpConfigAP configures an Access Point that will be used to configure the WiFi Station
+  mode settings.
+*/
+void setUpConfigAP() {
+  WiFi.mode(WIFI_AP);
+  isSet = WiFi.softAP(AP_SSID, AP_Password);
+
+  Trace(F("Initializing soft-AP ... "));
+  Traceln(isSet ? "Ready" : "Failed!");
+  
+  Trace(F("AP SSID :'"));
+  Traceln(F(AP_SSID));
+  Trace(F("AP Password :'"));
+  Traceln(F(AP_Password));
+  Trace(F("Server IP Address :'"));
+  Traceln(F(WiFi.softAPIP()));
+
+  if (MDNS.begin(AP_Server_Domain)) { 
+    Traceln("MDNS responder started \n");
+  }
+
+  server.on("/", HTTP_GET, handleRoot);
+  server.on("/quit", HTTP_GET, handleShutdown);
+  server.on("/update", HTTP_POST, handleUpdateSettings);
+  // handle cases when file is not found
+  server.onNotFound([]() {
+    server.send(404, "text/html", FPSTR(notFoundContent));
+  });
+
+  // enable CORS header in webserver results
+  server.enableCORS(true);
+
+  // enable ETAG header in webserver results from serveStatic handler
+  server.enableETag(true);
+
+  server.begin();
+  Traceln("HTTP server started");
+}
+
+/*
+  getWiFiStatusMsg provides a descriptive status message in relation to the wifi
+  connection attempts.
+*/
+string getWiFiStatusMsg() {
+  switch (WiFi.status()) {
+    cases WL_IDLE_STATUS:
+      return "Wi-Fi is in process of changing between statuses";
+    cases WL_NO_SSID_AVAIL:
+      return "Configured SSID cannot be reached";
+    cases WL_SCAN_COMPLETED
+      return "Scan Completed";
+    cases WL_CONNECT_FAILED:
+      return "connection failed");
+    cases WL_CONNECTION_LOST:
+      return "Connection lost";
+    cases WL_WRONG_PASSWORD:
+      return "Wrong password";
+    cases WL_DISCONNECTED:
+      return "WiFi disconnected";
+    default:
+      return "Connection Successful";
+    }
+}
+
+// Server Pages
+
+/*
+  handleRoot returns the webpage to be viewed when a GET request is made to (http://rfid.auth.local).
+*/
+void handleRoot() {
+  StreamString temp;
+  temp.reserve(500);  // Preallocate a large chunk to avoid memory fragmentation
+  temp.printf(FPSTR(rootContent), string(settings.SSID), MAX_SSID_LEN, MAX_SSID_LEN,
+          string(settings.Password), MAX_PASSWORD_LEN, MAX_PASSWORD_LEN);
+  server.send(200, "text/html", temp.c_str());
+}
+
+/*
+  handleShutdown enables the user to safely exit the configuration setup mode by shutting down
+  the server and resetting the WiFi mode to Station for the normal WiFi module running.
+*/
+void handleShutdown() {
+  server.send(404, "text/html", FPSTR(exitConfigModeContent));
+
+  Traceln(F("Shutting the server!"));
+  server.stop();
+
+  delay(500); // Wait for the server to completely shutdown.
+
+  Traceln(F("Restarting the ESP-01 chip CPU"));
+  ESP.restart();
+}
+
+/**
+  handleUpdateSettings extracts the sent WiFi parameters and attempts to write them into the
+  preset EEPROM memory address. If on trimming the white characters either the network name
+  or password are found to be empty, the update will fail.
+*/
+void handleUpdateSettings() {
+  // updateFailedEmphasis string is included in the update status webpage to indicate
+  // update failure if it happened.
+  string updateFailedEmphasis = "NOT";
+
+  if (server.hasArg("ssid") && server.hasArg("pwd")) {
+    string ssid = server.arg("ssid").trim();
+    string pwd = server.arg("pwd").trim();
+  
+    if (ssid.length() > 0 && pwd.length() > 0) {
+      ssid.toCharArray(settings.SSID, ssid.length()); // set the ssid string to the struct.
+      pwd.toCharArray(settings.Password, pwd.length()) // set the pwd string to the struct.
+
+      // Update the EEPROM with the latest settings.
+      EEPROM.put(STORAGE_ADDRESS, &settings);
+
+      // Remove the failure emphasis text indicating success of the update operation.
+      updateFailedEmphasis = ""; // its as 
+    }
+  }
+
+  StreamString temp;
+  temp.reserve(500);  // Preallocate a large chunk to avoid memory fragmentation
+  temp.printf(FPSTR(updateSuccessfulContent), updateFailedEmphasis, string(settings.SSID), string(settings.Password));
+  server.send(200, "text/html", temp.c_str());
+}

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -23,7 +23,7 @@
 //#define LED_BUILTIN 2
 
 // uncomment next line to get debug messages output to Serial link
-#define DEBUG
+//define DEBUG
 
 // When setting up the AP mode is used to set the Station WiFi settings the
 // following configuration is used:
@@ -69,7 +69,18 @@ void setup() {
   // Set the GPIO2 Pin as output and set it high.
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, LOW);
-  Serial.println(".");
+
+  #ifdef DEBUG
+  Serial.println("");
+  Serial.print(F("Core Version: "));
+  Serial.println(ESP.getCoreVersion());
+  Serial.print(F("SDK Version: "));
+  Serial.println(ESP.getSdkVersion());
+  Serial.print(F("Chip ID: "));
+  Serial.println(ESP.getChipId());
+  Serial.print(F("Reset Reason: "));
+  Serial.println(ESP.getResetReason());
+  #endif
 
   // Delay allows the serial interface to be ready.
   for (int i=0;i<5;i++) {

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -142,11 +142,20 @@ void loop() {
     // Switch on builtin status light to indicate API connection activity.
     digitalWrite(LED_BUILTIN, LOW);
 
+    // Read the contents of the serial buffer.
+    size_t bufferSize = Serial.available();
+    char buffer[bufferSize];
+    byte counter = 0;
+    while (Serial.available()) {
+      buffer[counter] = Serial.read();
+      counter++;
+    }
+
     WiFiClient client;
     HTTPClient http;
 
     #ifdef DEBUG 
-    Serial.println("[HTTP] begin...");
+    Serial.println("[HTTP] Setting the client config");
     #endif
 
     // configure traged server and url
@@ -154,10 +163,10 @@ void loop() {
     http.addHeader("Content-Type", "application/json");
 
     #ifdef DEBUG 
-    Serial.println("[HTTP] POST...");
+    Serial.println("[HTTP] Make a POST Request");
     #endif
     // start connection and send HTTP header and body
-    int httpCode = http.POST("{\"hello\":\"world\"}");
+    int httpCode = http.POST(String(buffer));
 
     // httpCode will be negative on error
     if (httpCode > 0) {
@@ -232,9 +241,11 @@ void setUpConfigAP() {
   Serial.print(F("AP SSID :'"));
   Serial.println(AP_SSID);
   Serial.print(F("AP Password :'"));
-  Serial.println(AP_Password);
+  Serial.print(AP_Password);
+  Serial.println(F("'"));
   Serial.print(F("Server IP Address :'"));
-  Serial.println(WiFi.softAPIP());
+  Serial.print(WiFi.softAPIP());
+  Serial.println(F("'"));
   #endif
 
   isSet  = MDNS.begin(AP_Server_Domain);

--- a/wifi-module/wifi-module.ino
+++ b/wifi-module/wifi-module.ino
@@ -1,3 +1,20 @@
+/*
+    @file This file contains the implementation of the code that runs on the WiFi
+    module (ESP-01s)
+
+    LED_BUILTIN defines the builtin LED available on GPIO2 in the ESP-01s
+    schematics. This LED should provide the visual confirmation of whether the chip
+    is running on the normal(Standby) mode or WiFi settings configuration mode.
+    During the configuration mode, the LED should either be blinking or consistently
+    on. The configurations mode only runs once immediately after the chip boots up
+    until the Station mode connectivity is established. If the builtin light is ON
+    but is not blinking, connect to the chip via its configuration A.P. mode and 
+    update the settings. The second confirmation of the configurations mode being
+    active is that, AP_SSID appears on the scanned available WiFi networks.
+    When the builtin light goes off, the connection has been established and the WiFi
+    module is running on the stand-by(normal) waiting for actual the HTTP requests.
+*/
+
 #include <EEPROM.h>
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
@@ -12,16 +29,6 @@
 // EEPROM_SIZE defines the EEPROM memory size to initialize.
 #define EEPROM_SIZE 320
 
-// LED_BUILTIN defines the builtin led on GPIO2 in the ESP-01s schematics.
-// This LED should provide the visual confirmation of whether the chip is
-// running on the normal mode or WiFi settings configuration mode.
-// During normal mode, the LED should blink atleast every 1secs,
-// if it stays on for longer than that most likely the WiFi configuration mode
-// is active.
-// The second confirmation of the WiFi settings mode being active should be the
-// AP_SSID appearing on the available networks on scanning the visible wireless networks.
-//#define LED_BUILTIN 2
-
 // uncomment next line to get debug messages output to Serial link
 //define DEBUG
 
@@ -29,8 +36,8 @@
 // following configuration is used:
 const char* AP_SSID = "RFID-based-Auth";
 const char* AP_Password = "Adm1n$tr8oR";
-// WiFi_Hostname defines part of the WiFi hostname. The full name with "RFID_AUTH_24xMac"
-// where "24xMac" represents the last 24 bits of the mac address.
+// WiFi_Hostname defines part of the WiFi hostname. The full name with
+// "RFID_AUTH_24xMac" where "24xMac" represents the last 24 bits of the mac address.
 const char* WiFi_Hostname = "RFID_AUTH";
 
 // multicast DNS is used to attach '.local' suffix to create the complete domain name
@@ -70,8 +77,8 @@ void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, LOW);
 
-  #ifdef DEBUG
   Serial.println("");
+  #ifdef DEBUG
   Serial.print(F("Core Version: "));
   Serial.println(ESP.getCoreVersion());
   Serial.print(F("SDK Version: "));
@@ -338,7 +345,6 @@ String getWiFiStatusMsg() {
     return status;
 }
 
-
 // Server Pages
 
 /*
@@ -421,9 +427,11 @@ void handleUpdateSettings() {
   server.send(200, "text/html", buffer);
 }
 
-// ReadWiFiSettingsInEEPROM reads the contents of the STORAGE_ADDRESS an formats the read data.
-// If the address read was empty, the default byte stored in that location is 0xff.
-// It removes the EEPROM empty char from the data read.
+/*
+  ReadWiFiSettingsInEEPROM reads the contents of the STORAGE_ADDRESS an formats the read data.
+  If the address read was empty, the default byte stored in that location is 0xff.
+  It removes the EEPROM empty char from the data read.
+ */
 void ReadWiFiSettingsInEEPROM() {
   EEPROM.get(STORAGE_ADDRESS, settings);
   String ssid = replaceEmptyBytes(settings.SSID, MAX_SSID_LEN);
@@ -432,10 +440,11 @@ void ReadWiFiSettingsInEEPROM() {
   ssid.toCharArray(settings.SSID, ssid.length()+1); // set the ssid string to the struct.
   pwd.toCharArray(settings.Password, pwd.length()+1); // set the pwd string to the struct.
 }
-
-// replaceEmptyBytes it replaces all the 0xff EEPROM empty characters with 0x20 which is a whitespace.
-// It then removes the trailing and preceeding whitespaces before reassigning the formatted array
-// back to the original array.
+/*
+  replaceEmptyBytes it replaces all the 0xff EEPROM empty characters with 0x20 which is a whitespace.
+  It then removes the trailing and preceeding whitespaces before reassigning the formatted array
+  back to the original array.
+*/
 String replaceEmptyBytes(char* rawStr, byte charCount){
   char data[charCount];
   for (byte i= 0; i<charCount; i++) {


### PR DESCRIPTION
To configure the WiFi module (ESP-01s) the chip needs to be booted up in the flash programming mode as described [here](https://www.forward.com.au/pfod/ESP8266/GPIOpins/ESP8266_01_pin_magic.html#programming).
When using Arduino IDE + esptool to upload software via Arduino Leonardo serially the following core version [modifications](https://github.com/espressif/esptool/issues/972#issuecomment-2054169803) might be necessary.

Internal workings of the WiFi Module
1. It initialises on Station mode where it attempt to connect to an Access Point using the preset WiFi settings.
2. If the connection fails, It creates a simple access point that is used to set the station mode WiFi settings.
3. Once done it, restart and the process above repeats till the station mode makes a connectivity.
4. On connectivity, it runs in the standby mode waiting for requests to process