### PR TITLE
Setup Reproducible Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 *.app
 
 .DS_Store
+.vscode
+*.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2024, Migwi Ndung'u
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# Directories
+RFID_AUTH_WORKING_DIR = ./rfid-plus-display
+WIFI_MODULE_WORKING_DIR = ./wifi-module
+
+# Toolchain
+TARGET_EXEC := arduino-cli
+
+# Targets
+UPLOAD_OP = upload
+COMPILE_OP = compile
+ESP_TARGET = esp
+RFID_TARGET = rfid
+
+# Flags
+OBJ := $(eval $(wildcard $(WORKING_DIR)/*.ino))
+CONFIG_FILE = --config-file $(WORKING_DIR)/arduino-cli.yaml
+JQ_COMMAND = ".detected_ports | . [] |  select( .matching_boards | length > 0) | .port.address"
+BOARD_PORT = $(shell $(TARGET_EXEC) board list --json | jq -c $(JQ_COMMAND))
+
+# Sets the working directory for the rfid target.
+$(RFID_TARGET): 
+	@echo "##Setting the working directory as $(RFID_AUTH_WORKING_DIR) \n"
+	$(eval WORKING_DIR := $(RFID_AUTH_WORKING_DIR))
+
+# Sets the working directory for the esp target.
+$(ESP_TARGET):
+	@echo "##Setting the working directory as $(WIFI_MODULE_WORKING_DIR) \n"
+	$(eval WORKING_DIR := $(WIFI_MODULE_WORKING_DIR))
+
+# Compiles the code in the rfid working directory.
+$(COMPILE_OP).$(RFID_TARGET): $(RFID_TARGET) $(OBJ)
+	@echo "## Compile the code on in $(WORKING_DIR) \n"
+	$(TARGET_EXEC) compile $(CONFIG_FILE) $(WORKING_DIR)
+
+# Compiles the code in the esp working directory.
+$(COMPILE_OP).$(ESP_TARGET): $(ESP_TARGET) $(OBJ)
+	@echo "## Compile the code on in $(WORKING_DIR) \n"	
+	$(TARGET_EXEC) compile $(CONFIG_FILE) $(WORKING_DIR)
+
+# Builds and Flashes the code in the rfid working directory to the arduino board.
+$(UPLOAD_OP).$(RFID_TARGET): $(RFID_TARGET) $(OBJ)
+	@echo "## Uploading the code on to Arduino on port $(BOARD_PORT) \n"
+	$(TARGET_EXEC) upload -p $(BOARD_PORT) $(CONFIG_FILE) $(WORKING_DIR)
+
+# Builds and Flashes the code in the esp working directory to the arduino board.
+$(UPLOAD_OP).$(ESP_TARGET):  $(ESP_TARGET) $(OBJ)
+	@echo "## Uploading the code on to Arduino on port $(BOARD_PORT) \n"
+	$(TARGET_EXEC) upload -p $(BOARD_PORT) $(CONFIG_FILE) $(WORKING_DIR)

--- a/rfid-plus-display/arduino-cli.yaml
+++ b/rfid-plus-display/arduino-cli.yaml
@@ -1,9 +1,5 @@
 # File configuration is described here:
-# https://arduino.github.io/arduino-cli/1.0/configuration/
-
-directories:
-    # The equivalent of the Arduino IDE's "sketchbook" directory
-    user: ../../      
+# https://arduino.github.io/arduino-cli/1.0/configuration/   
 
 logging:
     # path to the file where logs will be written

--- a/rfid-plus-display/arduino-cli.yaml
+++ b/rfid-plus-display/arduino-cli.yaml
@@ -1,0 +1,20 @@
+# File configuration is described here:
+# https://arduino.github.io/arduino-cli/1.0/configuration/
+
+directories:
+    # The equivalent of the Arduino IDE's "sketchbook" directory
+    user: ../../      
+
+logging:
+    # path to the file where logs will be written
+    file: "../rfid-plus-display.log"
+    # File logging format
+    format: txt
+    # File logging level as from warn, error, fatal to panic
+    level: warn
+
+build_cache:
+    # Make the build cache contents expire in 24 hrs
+    ttl: 24h
+    # Purge the cache after every build
+    compilations_before_purge: 1

--- a/rfid-plus-display/picc.cpp
+++ b/rfid-plus-display/picc.cpp
@@ -1,0 +1,18 @@
+/*!
+ * @file picc.cpp
+ *
+ * @section intro_sec Introduction
+ *
+ * This file is part rfid-plus-display package files. It is an implementation
+ * of the RFID PICC that runs on a adapter customised for AVR boards.
+ * It may work with other AVR boards but that cannot be guaranteed.
+ *
+ * @section author Author
+ *
+ * Written by dmigwi (Migwi Ndung'u)  @2024
+ * LinkedIn: https://www.linkedin.com/in/migwi-ndungu/
+ *
+ *  @section license License
+ *
+ * BSD license, all text here must be included in any redistribution.
+ */

--- a/rfid-plus-display/picc.h
+++ b/rfid-plus-display/picc.h
@@ -1,0 +1,18 @@
+/*!
+ * @file picc.h
+ *
+ * @section intro_sec Introduction
+ *
+ * This file is part rfid-plus-display package files. It is an implementation
+ * of the RFID PICC that runs on a adapter customised for AVR boards.
+ * It may work with other AVR boards but that cannot be guaranteed.
+ *
+ * @section author Author
+ *
+ * Written by dmigwi (Migwi Ndung'u)  @2024
+ * LinkedIn: https://www.linkedin.com/in/migwi-ndungu/
+ *
+ *  @section license License
+ *
+ * BSD license, all text here must be included in any redistribution.
+ */

--- a/rfid-plus-display/rfid-plus-display.ino
+++ b/rfid-plus-display/rfid-plus-display.ino
@@ -1,4 +1,3 @@
-
 // include the library code:
 #include "Arduino.h"
 #include <LiquidCrystal.h>

--- a/rfid-plus-display/sketch.yaml
+++ b/rfid-plus-display/sketch.yaml
@@ -1,0 +1,16 @@
+# File configuration is described here:
+# https://arduino.github.io/arduino-cli/1.0/sketch-project-file/
+
+profiles:
+  leonardo:
+    notes: It enables a reproduceable builds from the rfid-plus-display project
+    fqbn: arduino:avr:leonardo
+
+    platforms:
+      - platform: arduino:avr (1.8.6)
+
+    libraries:
+      - LiquidCrystal (1.0.7)
+
+default_profile: leonardo
+default_protocol: serial

--- a/wifi-module/arduino-cli.yaml
+++ b/wifi-module/arduino-cli.yaml
@@ -4,11 +4,7 @@
 board_manager:
     # URLs to any additional Boards Manager package index files needed for your boards platforms.
     additional_urls: 
-     - http://arduino.esp8266.com/stable/package_esp8266com_index.json
-
-directories:
-    # The equivalent of the Arduino IDE's "sketchbook" directory
-    user: ../../      
+     - http://arduino.esp8266.com/stable/package_esp8266com_index.json     
 
 logging:
     # path to the file where logs will be written

--- a/wifi-module/arduino-cli.yaml
+++ b/wifi-module/arduino-cli.yaml
@@ -1,0 +1,25 @@
+# File configuration is described here:
+# https://arduino.github.io/arduino-cli/1.0/configuration/
+
+board_manager:
+    # URLs to any additional Boards Manager package index files needed for your boards platforms.
+    additional_urls: 
+     - http://arduino.esp8266.com/stable/package_esp8266com_index.json
+
+directories:
+    # The equivalent of the Arduino IDE's "sketchbook" directory
+    user: ../../      
+
+logging:
+    # path to the file where logs will be written
+    file: "../wifi-module.log"
+    # File logging format
+    format: txt
+    # File logging level as from warn, error, fatal to panic
+    level: warn
+
+build_cache:
+    # Make the build cache contents expire in 24 hrs
+    ttl: 24h
+    # Purge the cache after every build
+    compilations_before_purge: 1

--- a/wifi-module/sketch.yaml
+++ b/wifi-module/sketch.yaml
@@ -1,0 +1,20 @@
+# File configuration is described here:
+# https://arduino.github.io/arduino-cli/1.0/sketch-project-file/
+
+profiles:
+  esp01s:
+    notes: It enables a reproduceable builds from the wifi-module project
+    fqbn: esp8266:esp8266:generic
+
+    platforms:
+      - platform: esp8266:esp8266 (3.1.2)
+        platform_index_url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
+
+    libraries:
+      - ESP8266WiFi (1.0.2)
+      - ESP8266WebServer (0.6.4)
+      - ESP8266mDNS (1.1.0)
+      - ESP8266mDNS (1.1.0)
+
+default_profile: esp01s
+default_protocol: serial


### PR DESCRIPTION
- Adds the arduino-cli configuration that is used to compile and flash the code without the need of an ide
- Add a BDS License
- Introduces config file and sketch.yaml file that help in making reproducible builds.
- Alls a Makefile configuration